### PR TITLE
Change skipped step icon to heavy_minus_sign

### DIFF
--- a/__tests__/job_status.test.ts
+++ b/__tests__/job_status.test.ts
@@ -105,7 +105,7 @@ test('push event to slack', async () => {
             short: false,
             title: 'Job Steps',
             value:
-              ':no_entry_sign: install-deps\n:no_entry_sign: hooks\n:no_entry_sign: lint\n:no_entry_sign: types\n:no_entry_sign: unit-test\n:no_entry_sign: integration-test'
+              ':heavy_minus_sign: install-deps\n:heavy_minus_sign: hooks\n:heavy_minus_sign: lint\n:heavy_minus_sign: types\n:heavy_minus_sign: unit-test\n:heavy_minus_sign: integration-test'
           }
         ],
         footer: '<https://github.com/act10ns/slack|act10ns/slack> #8',

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -13,7 +13,7 @@ function stepIcon(status: string): string {
   if (status.toLowerCase() === 'success') return ':heavy_check_mark:'
   if (status.toLowerCase() === 'failure') return ':x:'
   if (status.toLowerCase() === 'cancelled') return ':exclamation:'
-  if (status.toLowerCase() === 'skipped') return ':no_entry_sign:'
+  if (status.toLowerCase() === 'skipped') return ':heavy_minus_sign:'
   return `:grey_question: ${status}`
 }
 


### PR DESCRIPTION
Thanks a bunch for creating this Action!

Skipped steps are currently indicated with the `:no_entry_sign:` (:no_entry_sign:) emoji, which shows up in red and looks like something has gone wrong. This change would use `:heavy_minus_sign:` (:heavy_minus_sign:) instead, less alarming and more consistent with the GitHub Actions UI.

I'm also open to making this customizable if you think that's better.