### PR TITLE
Quote workflow names to fix workflows containing spaces

### DIFF
--- a/src/slack.ts
+++ b/src/slack.ts
@@ -144,7 +144,7 @@ export async function send(
 
   const runId = process.env.GITHUB_RUN_ID
   const runNumber = process.env.GITHUB_RUN_NUMBER
-  const workflowUrl = `${repositoryUrl}/actions?query=workflow:${workflow}`
+  const workflowUrl = `${repositoryUrl}/actions?query=workflow:"${workflow}"`
   const workflowRunUrl = `${repositoryUrl}/actions/runs/${runId}`
 
   const sha = process.env.GITHUB_SHA as string


### PR DESCRIPTION
When the workflow name contains a space, only the first word of the workflow is captured in the search URL, causing the search to be incorrect. This adds quotes so that the full workflow name is always captured.